### PR TITLE
initialize global GOPATH and GOROOT

### DIFF
--- a/sg_sublime.py
+++ b/sg_sublime.py
@@ -13,6 +13,8 @@ import urllib.request
 SOURCEGRAPH_CHANNEL = None
 SETTINGS_FILENAME = 'Sourcegraph.sublime-settings'
 SETTINGS = None
+GOPATH = None
+GOROOT = None
 
 def load_settings():
 	global SOURCEGRAPH_BASE_URL


### PR DESCRIPTION
Initialize GOPATH and GOROOT so that they can be used elsewhere. Sam has had issues and suggested this fix. 